### PR TITLE
fix argument mismatch error in gcc10

### DIFF
--- a/src/AB13ID.f
+++ b/src/AB13ID.f
@@ -396,7 +396,7 @@ C     .. Local Scalars ..
      $                   LUPD, MAXACC
       INTEGER            I, ISV, ITAU, IWRK, IWS, J, K, MAXMP, MAXWRK,
      $                   MINWRK, N1, NA, RANKA
-      DOUBLE PRECISION   PREC, SVLMAX, THRESH, TOLDEF
+      DOUBLE PRECISION   PREC, SVLMAX, THRESH, TOLDEF, RCOND
 C
 C     .. Local Arrays ..
       DOUBLE PRECISION   DUM( 2 ), TOLV( 3 )
@@ -511,7 +511,8 @@ C
      $                      INFO )
                MAXWRK = MAX( MAXWRK, INT( DWORK( 1 ) ) )
             END IF
-            CALL MB03OD( 'QR Decomposition', N, N, E, LDE, IWORK, TOL,
+            RCOND = TOL( 1 )
+            CALL MB03OD( 'QR Decomposition', N, N, E, LDE, IWORK, RCOND,
      $                   ZERO, DWORK, RANKE, DWORK, DUM, -1, INFO )
             MAXWRK = MAX( MAXWRK, INT( DUM( 1 ) ) + N + 3 )
             CALL DORMQR( 'Left', 'Transpose', N, N, N, E, LDE, DWORK, A,


### PR DESCRIPTION
Hello,

over at [Slycot](https://github.com/python-control/Slycot) we have been maintaining a fork of the SLICOT 5.0 GPL sources. Over time, we implemented some small fixes to build SLICOT with updated versions of gcc and the various BLAS/LAPACK implementations.

The individual fixes would have to be submitted to this BSD licensed repository by the respective authors, because Slycot is currently stuck on GPL, but I can start with my own contribution:

gfortran10 started to throw errors because of a rank mismatch when calling MB03OD (see also https://gcc.gnu.org/gcc-10/porting_to.html):
```
[  9%] Building Fortran object slycot/CMakeFiles/_wrapper.dir/src/SLICOT-Reference/src/AB13ID.f.o
/home/ben/src/Slycot/slycot/src/SLICOT-Reference/src/AB13ID.f:640:19:

  514 |             CALL MB03OD( 'QR Decomposition', N, N, E, LDE, IWORK, TOL,
      |                                                                  2
......
  640 |      $             TOLDEF, SVLMAX, DWORK, RANKE, DWORK( NR+1 ),
      |                   1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
/home/ben/src/Slycot/slycot/src/SLICOT-Reference/src/AB13ID.f:787:39:

  514 |             CALL MB03OD( 'QR Decomposition', N, N, E, LDE, IWORK, TOL,
      |                                                                  2
......
  787 |      $                   IWORK( IWS ), TOLDEF, SVLMAX, DWORK( ITAU ),
      |                                       1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
/home/ben/src/Slycot/slycot/src/SLICOT-Reference/src/AB13ID.f:799:25:

  514 |             CALL MB03OD( 'QR Decomposition', N, N, E, LDE, IWORK, TOL,
      |                                                                  2
......
  799 |      $                   TOLDEF, SVLMAX, DWORK, RANKA, DWORK( ISV ),
      |                         1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
```

This PR fixes the issue.