### PR TITLE
Fix:  IB01AD: Incorrect calculation of minimal working space

### DIFF
--- a/src/IB01AD.f
+++ b/src/IB01AD.f
@@ -578,7 +578,7 @@ C
             ELSE IF ( FQRALG ) THEN
                IF ( .NOT.ONEBCH .AND. CONNEC ) THEN
                   MINWRK = NR*( M + L + 3 )
-               ELSE IF ( FIRST .OR. INTERM ) THEN
+               ELSE IF ( (FIRST .OR. INTERM).AND..NOT.ONEBCH ) THEN
                   MINWRK = NR*( M + L + 1 )
                ELSE
                   MINWRK = 2*NR*( M + L + 1 ) + NR


### PR DESCRIPTION
When subroutine IB01AD call with parameters `ALG='F'`  and `BATCH='O'`  minimal needed workspace should be calculated by expression  `MINWRK = 2*NR*( M + L + 1 ) + NR`  (line 584) but it calculating in line 582 `MINWRK = NR*( M + L + 1 )`. It is because logical `FIRST`   is always `true`  when `BATCH='O'` .